### PR TITLE
v0.32.2

### DIFF
--- a/ptbCorgi/functionLibrary/GUI/pmGui.m
+++ b/ptbCorgi/functionLibrary/GUI/pmGui.m
@@ -376,7 +376,7 @@ try
 catch ME
     disp('<><><><><><> PTBCORGI <><><><><><><>')
     disp('ERROR Loading Paradigm File, check your paradigm file')
-    disp('The following report should help diagnose what is wrong:')
+    disp('Read the messages above to help diagnose what is wrong')
     disp(' ')
     disp(getReport(ME))
     

--- a/ptbCorgi/functionLibrary/closeExperiment.m
+++ b/ptbCorgi/functionLibrary/closeExperiment.m
@@ -8,6 +8,5 @@ function closeExperiment()
 Priority(0); %Restore priority settings
 RestoreCluts; %Restore gamma table
 Screen('CloseAll'); %close open windows/textures
-PsychPortAudio('Close'); %
 ListenChar(0); %Show Keypresses
 ShowCursor(); %Show cursor

--- a/ptbCorgi/functionLibrary/openExperiment.m
+++ b/ptbCorgi/functionLibrary/openExperiment.m
@@ -31,8 +31,6 @@ function expInfo = openExperiment( expInfo)
 clear PsychHID;
 clear KbCheck;
 
-%Close psychPortAudio handles if left open by crash
-PsychPortAudio('Close');
 %
 % This is a line that is easily skipped/missed but is important
 % Various default setup options, including color as float 0-1;
@@ -375,12 +373,16 @@ end
 
 %Figure out a better way of handling turning on/off audio.
 if ~isfield(expInfo,'enableAudio')
-    expInfo.enableAudio = true;
+    expInfo.enableAudio = false;
 end
 
-%TODO: clean up this code. 
+%TODO: add more user controllable options. 
 if expInfo.enableAudio
+    %Must call InitialzePsychSound before any call to PsychPortAudio
     InitializePsychSound
+    
+    %Close psychPortAudio handles if left open by crash
+    PsychPortAudio('Close');
     
     %Basic audio information for interval beeps and audio
     %feedback
@@ -392,7 +394,6 @@ if expInfo.enableAudio
     audioInfo.beepFreq = 500;
     audioInfo.startCue = 0; %starts immediately on call
     audioInfo.ibi = 0.05; %inter-beep interval; only used for the second interval
-    audioInfo.pahandle = [];%PsychPortAudio('Open', [], 1, 1, audioInfo.samplingFreq, audioInfo.nOutputChannels);
     audioInfo.postFeedbackPause = 0.25;
     thisBeep = MakeBeep(500, audioInfo.beepLength, audioInfo.samplingFreq);
     audioInfo.intervalBeep = repmat(thisBeep,audioInfo.nOutputChannels,1);
@@ -403,9 +404,10 @@ if expInfo.enableAudio
     thisBeep = MakeBeep(250, audioInfo.beepLength, audioInfo.samplingFreq);
     audioInfo.incorrectSnd = repmat(thisBeep,audioInfo.nOutputChannels,1);
     
-             
-    
-    audioInfo.pahandle = PsychPortAudio('Open', [], [], 0, [], 2);
+    %Now lets open an audio device
+    latencyClass = 0;
+    audioInfo.pahandle = PsychPortAudio('Open',...
+        [], 1, latencyClass, audioInfo.samplingFreq, audioInfo.nOutputChannels);
     expInfo.audioInfo = audioInfo;
     
 end

--- a/ptbCorgi/functionLibrary/ptbCorgiLoadParadigm.m
+++ b/ptbCorgi/functionLibrary/ptbCorgiLoadParadigm.m
@@ -32,26 +32,44 @@ if ischar(paradigmFile)
     if strcmp(fileExt,'.m')
         paradigmFile = str2func(fileName);
         
-        %Check if the paradigm function location is on the path
-        if ~ismember(filePath, strsplit(path, pathsep))            
-            warning('ptbCorgi:loadParadigm:functionNotOnPath',...
-                'Paradigm function (*.m) files must be on the matlab path\n adding %s to the path',...
-            filePath); 
-            addpath(filePath);
-        end
         
-        %After adding it to the path check if we've got duplicates hiding.
+        %Check how many copies of the paradigm file is on the path.
         fileLocations = which(fileName,'-all');
         
+        
+        %If there's more than one location quit now and tell user to fix
+        %the problem.
         if length(fileLocations) >1
-            fprintf(2,'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            fprintf(2,'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n');
              fprintf(2,'Cannot load paradigm %s! Duplicate functions found on path:\n',fileName);
              disp(char(fileLocations));
             error('ptbCorgi:loadParadigm:shadowParadigm',...
                 'Multiple files share paradigm function name, rename paradigm file')
-                
-        end
+            
+        elseif isempty(fileLocations) %If the paradigm can't be found it must not be on the path, add it
+            warning('ptbCorgi:loadParadigm:functionNotOnPath',...
+                'Paradigm function (*.m) files must be on the matlab path\n adding %s to the path',...
+                filePath);
         
+            addpath(filePath);
+        else %Ok it's on the path.  But is it the correct file on the path?
+            
+            %Check if the paradigm function location is on the path
+            if ~ismember(filePath, strsplit(path, pathsep))
+                
+                fprintf(2,'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n');
+                fprintf(2,'Cannot load paradigm %s! Duplicate functions found on path:\n',fileName);
+                fprintf(2,'You requested to load: %s\n',fullfile(filePath, fileName, fileExt));
+                fprintf(2,'But this different file is already on the matlab path: %s\n', fileLocations{1});
+                fprintf(2,'Rename one of the paradigms or fix the matlab path. Please note ptbCorgi automatically adds subdirectories of the basedir to the path\n');
+                error('ptbCorgi:loadParadigm:shadowParadigm',...
+                    'Multiple files share paradigm function name, rename paradigm file')
+                                
+            end
+            
+        end
+                           
+                
     elseif ~strcmp(fileExt,'.mat')
         error('ptbCorgi:loadParadigm:inputError',...
             'File must be either *.m or *.mat');

--- a/ptbCorgi/ptbCorgi.m
+++ b/ptbCorgi/ptbCorgi.m
@@ -281,6 +281,19 @@ disp('Use ptbCorgiSetup() to redefine defaults');
         return;
     end
     
+    %If any conditions request audiofeedback that forces enabling audio.
+    %If any conditions request interval beeps played that forces audio
+    %Add any other checks for things that require audio here
+    if  any( [conditionInfo(:).giveAudioFeedback]) ...
+            || (isfield(conditionInfo,'intervalBeep') && any([conditionInfo(:).intervalBeep]))        
+        
+        if isfield(expInfo,'enableAudio') && ~expInfo.enableAudio
+            warning('ptbCorgi:ptbCorgi:audioForced',...
+                'User requested disabling audio, however conditionInfo requested providing audio feedback. Forcing audio to be enabled');
+        end
+        expInfo.enableAudio = true;        
+    end
+    
     sessionInfo.expInfoBeforeOpenExperiment = expInfo;
     
     %Now lets begin the experiment and loop over the conditions to show.


### PR DESCRIPTION
Added checks to ensure audio is enabled when implicitly needed by conditions.

Ensured calls to PsychPortAudio() only happen after InitializePsychPortAudio has been run. 
Added more informative checks and error messages when attempting to load a paradigm that conflicts with others on the path.